### PR TITLE
adding an assembly editor

### DIFF
--- a/include/cpp_box/compiler.hpp
+++ b/include/cpp_box/compiler.hpp
@@ -61,6 +61,7 @@ Loaded_Files compile(const std::string &t_str,
                      const std::filesystem::path &t_hardware_lib,
                      const std::string_view t_optimization_level,
                      const std::string_view t_standard,
-                     spdlog::logger &logger);
+                     spdlog::logger &logger,
+                     bool is_cpp_mode = true);
 
 }  // namespace cpp_box

--- a/lib/compiler.cpp
+++ b/lib/compiler.cpp
@@ -82,8 +82,6 @@ Loaded_Files compile(const std::string &t_str,
                      spdlog::logger &logger,
                      bool is_cpp_mode)
 {
-  is_cpp_mode = false; // TODO
-
   logger.info("Compile Starting");
 
   cpp_box::utility::Temp_Directory dir{};
@@ -99,13 +97,12 @@ Loaded_Files compile(const std::string &t_str,
     ofs.flush();  // make sure OS flushes file before clang tries to load it
   }
 
-  // TODO "-save-temps=obj"
   const std::string_view common_flags = "-g --target=arm-none-elf -march=armv4 -mfloat-abi=hard";
 
   std::string build_command;
   if(is_cpp_mode) {
     build_command = fmt::format(
-      R"("{}" -std={} "{}" -c -o "{}" -O{} -nostdinc -I"{}" -I"{}" -I"{}" -D__ELF__ -D_LIBCPP_HAS_NO_THREADS {} -mfpu=vfp)",
+      R"("{}" -std={} "{}" -c -o "{}" -O{} -nostdinc -save-temps=obj -I"{}" -I"{}" -I"{}" -D__ELF__ -D_LIBCPP_HAS_NO_THREADS {} -mfpu=vfp)",
       t_clang_compiler.string(),
       std::string(t_standard),
       cpp_file.string(),
@@ -118,11 +115,10 @@ Loaded_Files compile(const std::string &t_str,
       );
   } else {
     build_command = fmt::format(
-      R"("{}" "{}" -c -o "{}" -O{} {})",
+      R"("{}" "{}" -c -o "{}" {})",
       t_clang_compiler.string(),
       asm_file.string(),
       obj_file.string(),
-      std::string(t_optimization_level),
       common_flags
       );
   }

--- a/lib/compiler.cpp
+++ b/lib/compiler.cpp
@@ -100,12 +100,12 @@ Loaded_Files compile(const std::string &t_str,
   }
 
   // TODO "-save-temps=obj"
-  const std::string_view common_flags = "-g --target=arm-none-elf -march=armv4 -mfpu=vfp -mfloat-abi=hard";
+  const std::string_view common_flags = "-g --target=arm-none-elf -march=armv4 -mfloat-abi=hard";
 
   std::string build_command;
   if(is_cpp_mode) {
     build_command = fmt::format(
-      R"("{}" -std={} "{}" -c -o "{}" -O{} -nostdinc -I"{}" -I"{}" -I"{}" -D__ELF__ -D_LIBCPP_HAS_NO_THREADS {})",
+      R"("{}" -std={} "{}" -c -o "{}" -O{} -nostdinc -I"{}" -I"{}" -I"{}" -D__ELF__ -D_LIBCPP_HAS_NO_THREADS {} -mfpu=vfp)",
       t_clang_compiler.string(),
       std::string(t_standard),
       cpp_file.string(),
@@ -117,10 +117,9 @@ Loaded_Files compile(const std::string &t_str,
       common_flags
       );
   } else {
-    // TODO construct the command in a controlled environment
     build_command = fmt::format(
-      R"("{}" "{}" -o "{}" -O{} {})",
-      "/usr/bin/clang",// t_clang_compiler.string(), // TODO
+      R"("{}" "{}" -c -o "{}" -O{} {})",
+      t_clang_compiler.string(),
       asm_file.string(),
       obj_file.string(),
       std::string(t_optimization_level),

--- a/src/cpp_box.cpp
+++ b/src/cpp_box.cpp
@@ -80,6 +80,7 @@ struct Box
   struct Status
   {
     enum class States { Static, Running, Begin_Build, Paused, Parse_Build_Results, Reset, Reset_Timer, Start, Step_One, Check_Goal };
+    enum class Languages : int { Cpp, Assembly };
 
     spdlog::logger &m_logger;
 
@@ -91,6 +92,8 @@ struct Box
     sf::Clock framerateClock;
     std::array<std::uint32_t, 16> last_registers{};
     std::uint32_t last_CSPR{};
+
+    Languages language { Languages::Cpp };
 
     // TODO: move somewhere shared
     struct Timer
@@ -385,12 +388,18 @@ struct Box
     ImGui::End();
 
 
-    ImGui::Begin("C++");
+    ImGui::Begin("Editor");
     {
       if (status.loaded_files.src.size() - strlen(status.loaded_files.src.c_str()) < 256) {
         status.loaded_files.src.resize(status.loaded_files.src.size() + 512);
       }
+
+      ImGui::RadioButton("C++", reinterpret_cast<int*>(&status.language), static_cast<int>(Status::Languages::Cpp));
+      ImGui::SameLine();
+      ImGui::RadioButton("Assembly", reinterpret_cast<int*>(&status.language), static_cast<int>(Status::Languages::Assembly));
+      ImGui::SameLine();
       ImGui::Checkbox("Show Assembly", &status.show_assembly);
+
       const auto available = ImGui::GetContentRegionAvail();
       ImGui::BeginChild("Code", { status.show_assembly ? (available.x * 5 / 8) : available.x, available.y });
       {

--- a/src/cpp_box.cpp
+++ b/src/cpp_box.cpp
@@ -525,9 +525,12 @@ struct Box
            src                 = status.loaded_files.src,
            clang_compiler      = this->clang_compiler,
            freestanding_stdlib = this->freestanding_stdlib,
-           hardware_lib        = this->hardware_lib]() {
+           hardware_lib        = this->hardware_lib,
+           language            = status.language]() {
+            const bool is_cpp_mode = language == Status::Languages::Cpp;
+
             // string is oversized to allow for a buffer for IMGUI, need to only compile the first part of it
-            return cpp_box::compile(src.substr(0, src.find('\0')), clang_compiler, freestanding_stdlib, hardware_lib, "3", "c++2a", *console);
+            return cpp_box::compile(src.substr(0, src.find('\0')), clang_compiler, freestanding_stdlib, hardware_lib, "3", "c++2a", *console, is_cpp_mode);
           });
         status.needs_build = false;
         break;


### PR DESCRIPTION
This pull requests adds a radio buttons in the "Editor" window (previously called "C++") for language selection, the options being "C++" and "Assembly". This is the "Assembly" switch I requested in #40. 

In "C++" mode everything will work as it used to. If "Assembly" is selected then the code is passed as `src.s` to Clang which takes care of the rest. I am no expert in ARM-assembly but the programs I've tested just worked fine (except the `main:` see below for details).

There are a few things that need to be addressed though:

1. `cpp_box::compile` takes eight arguments now and passed the line of "this is madness".

2. The "Show Assembly" button is superfluous in "Assembly" mode, since it displays the same contents already present in the code box. I've tried to simply hide the button (and the corresponding panel), but check boxes are bigger than radio buttons and the code box becomes a tiny infuriating amount bigger (this may seem ridiculous but it can't be unseen).

3. When the emulator tries to execute an invalid or not implemented instruction, it will crash. In "C++" mode it's quite difficult to create a program which utilizes instructions which are not implemented or invalid. In "Assembly" mode this is quite easy, e.g. `main:` will do.

The following program definitely works (it's difficult to write bigger programs because copy + paste doesn't seem to work):

~~~
main:
        mov r0, #0
loop:
        add r0, #1
        b loop
~~~
